### PR TITLE
카프카 및 Outbox 패턴 추가

### DIFF
--- a/concert/build.gradle
+++ b/concert/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 	implementation 'net.datafaker:datafaker:1.8.0'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	testImplementation 'it.ozimov:embedded-redis:0.7.2'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/concert/docker/kafka-docker-compose.yml
+++ b/concert/docker/kafka-docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3"
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "echo ruok | nc 127.0.0.1 2181 | grep imok"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG_RETENTION_HOURS: 24
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: always
+    depends_on:
+      - zookeeper
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--zookeeper", "zookeeper:2181", "--list"]
+      interval: 30s
+      timeout: 10s

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/BaseEntity.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/BaseEntity.java
@@ -4,10 +4,12 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @MappedSuperclass
 @NoArgsConstructor
 public class BaseEntity {

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/Outbox.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/Outbox.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @Table(name = "outbox", indexes = {
-        @Index(name = "idx_status", columnList = "status")
+        @Index(name = "idx_status", columnList = "status"),
+        @Index(name = "idx_eventId", columnList = "eventId")
 })
 public class Outbox extends BaseEntity{
     @Id
@@ -22,6 +24,9 @@ public class Outbox extends BaseEntity{
 
     private String topic;
 
+    @Column(unique = true)
+    private UUID eventId;
+
     private String payload;
 
     private LocalDateTime updatedAt;
@@ -32,10 +37,11 @@ public class Outbox extends BaseEntity{
         FAILED
     }
 
-    public Outbox(String topic, String payload) {
+    public Outbox(String topic, String payload, UUID eventId) {
         this.status = OutboxStatus.INIT;
         this.topic = topic;
         this.payload = payload;
+        this.eventId = eventId;
     }
 
     public void updateFailedStatus() {

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/Outbox.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/Outbox.java
@@ -1,0 +1,51 @@
+package com.hhp.concert.Business.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Outbox extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private OutboxStatus status;
+
+    private String topic;
+
+    private String payload;
+
+    private LocalDateTime updatedAt;
+
+    public enum OutboxStatus {
+        INIT,
+        PUBLISH,
+        FAILED
+    }
+
+    public Outbox(String topic, String payload) {
+        this.status = OutboxStatus.INIT;
+        this.topic = topic;
+        this.payload = payload;
+    }
+
+    public void updateFailedStatus() {
+        this.status = OutboxStatus.FAILED;
+    }
+    public void updatePublishStatus() {
+        this.status = OutboxStatus.PUBLISH;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+}

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/Outbox.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/Outbox.java
@@ -9,6 +9,9 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(name = "outbox", indexes = {
+        @Index(name = "idx_status", columnList = "status")
+})
 public class Outbox extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/Reservation.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/Reservation.java
@@ -18,6 +18,8 @@ public class Reservation extends BaseEntity{
 
     private Long userId;
 
+    private Long concertId;
+
     private Long concertSessionId;
 
     private Long concertSeatId;
@@ -31,17 +33,19 @@ public class Reservation extends BaseEntity{
     @Version
     private long version;
 
-    public Reservation(Long id, Long userId, Long concertSessionId, Long concertSeatId, int reservationPrice, ReservationStatus status) {
+    public Reservation(Long id, Long userId, Long concertId, Long concertSessionId, Long concertSeatId, int reservationPrice, ReservationStatus status) {
         this.id = id;
         this.userId = userId;
+        this.concertId = concertId;
         this.concertSessionId = concertSessionId;
         this.concertSeatId = concertSeatId;
         this.reservationPrice = reservationPrice;
         this.status = status;
     }
 
-    public Reservation(Long userId, Long concertSessionId, Long concertSeatId, int price) {
+    public Reservation(Long userId, Long concertId,  Long concertSessionId, Long concertSeatId, int price) {
         this.userId = userId;
+        this.concertId = concertId;
         this.concertSessionId = concertSessionId;
         this.concertSeatId = concertSeatId;
         this.reservationPrice = price;

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/event/DataPlatformSendEvent.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/event/DataPlatformSendEvent.java
@@ -1,5 +1,0 @@
-package com.hhp.concert.Business.Domain.event;
-
-
-public record DataPlatformSendEvent<T>(T data) {
-}

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/event/DataPlatformSendEvent.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/event/DataPlatformSendEvent.java
@@ -1,4 +1,4 @@
-package com.hhp.concert.Business.Domain;
+package com.hhp.concert.Business.Domain.event;
 
 
 public record DataPlatformSendEvent<T>(T data) {

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/event/ReservationEvent.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/event/ReservationEvent.java
@@ -1,9 +1,39 @@
 package com.hhp.concert.Business.Domain.event;
 
 
-public record ReservationEvent(long concertId,
-                               String concertTitle,
-                               long seatId,
-                               int seatNumber,
-                               long outboxId
-                               ) {}
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReservationEvent{
+    long concertId;
+    String concertTitle;
+    long seatId;
+    int seatNumber;
+    @Setter
+    long outboxId;
+
+    public ReservationEvent(long concertId, String concertTitle, long seatId, int seatNumber) {
+        this.concertId = concertId;
+        this.concertTitle = concertTitle;
+        this.seatId = seatId;
+        this.seatNumber = seatNumber;
+    }
+
+    @JsonCreator
+    public ReservationEvent(@JsonProperty("concertId") Long concertId,
+                            @JsonProperty("concertTitle") String concertTitle,
+                            @JsonProperty("seatId") Long seatId,
+                            @JsonProperty("seatNumber") int seatNumber) {
+        this.concertId = concertId;
+        this.concertTitle = concertTitle;
+        this.seatId = seatId;
+        this.seatNumber = seatNumber;
+    }
+}

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/event/ReservationEvent.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/event/ReservationEvent.java
@@ -6,24 +6,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+
+import java.util.UUID;
 
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class ReservationEvent{
-    long concertId;
-    String concertTitle;
-    long seatId;
-    int seatNumber;
-    @Setter
-    long outboxId;
+    private UUID eventId;
+    private long concertId;
+    private String concertTitle;
+    private long seatId;
+    private int seatNumber;
 
     public ReservationEvent(long concertId, String concertTitle, long seatId, int seatNumber) {
         this.concertId = concertId;
         this.concertTitle = concertTitle;
         this.seatId = seatId;
         this.seatNumber = seatNumber;
+        this.eventId = UUID.randomUUID();
     }
 
     @JsonCreator
@@ -35,5 +36,6 @@ public class ReservationEvent{
         this.concertTitle = concertTitle;
         this.seatId = seatId;
         this.seatNumber = seatNumber;
+        this.eventId = UUID.randomUUID();
     }
 }

--- a/concert/src/main/java/com/hhp/concert/Business/Domain/event/ReservationEvent.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Domain/event/ReservationEvent.java
@@ -1,0 +1,9 @@
+package com.hhp.concert.Business.Domain.event;
+
+
+public record ReservationEvent(long concertId,
+                               String concertTitle,
+                               long seatId,
+                               int seatNumber,
+                               long outboxId
+                               ) {}

--- a/concert/src/main/java/com/hhp/concert/Business/Repository/OutboxRepository.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Repository/OutboxRepository.java
@@ -5,10 +5,11 @@ import com.hhp.concert.Business.Domain.Outbox;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface OutboxRepository {
     Outbox save(Outbox outbox);
-    Optional<Outbox> findById(Long id);
+    Optional<Outbox> findByEventId(UUID eventId);
 
     List<Outbox> findAllByStatus(Outbox.OutboxStatus outboxStatus);
 }

--- a/concert/src/main/java/com/hhp/concert/Business/Repository/OutboxRepository.java
+++ b/concert/src/main/java/com/hhp/concert/Business/Repository/OutboxRepository.java
@@ -1,0 +1,14 @@
+package com.hhp.concert.Business.Repository;
+
+import com.hhp.concert.Business.Domain.Outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface OutboxRepository {
+    Outbox save(Outbox outbox);
+    Optional<Outbox> findById(Long id);
+
+    List<Outbox> findAllByStatus(Outbox.OutboxStatus outboxStatus);
+}

--- a/concert/src/main/java/com/hhp/concert/Business/service/OutboxService.java
+++ b/concert/src/main/java/com/hhp/concert/Business/service/OutboxService.java
@@ -1,0 +1,10 @@
+package com.hhp.concert.Business.service;
+
+import com.hhp.concert.Business.Domain.Outbox;
+
+public interface OutboxService {
+    Outbox initOutbox(String topic, Object message);
+    void updatePublishedOutbox(Long outboxId);
+
+    void retryOutboxEvents();
+}

--- a/concert/src/main/java/com/hhp/concert/Business/service/OutboxService.java
+++ b/concert/src/main/java/com/hhp/concert/Business/service/OutboxService.java
@@ -2,9 +2,11 @@ package com.hhp.concert.Business.service;
 
 import com.hhp.concert.Business.Domain.Outbox;
 
+import java.util.UUID;
+
 public interface OutboxService {
-    Outbox initOutbox(String topic, Object message);
-    void updatePublishedOutbox(Long outboxId);
+    Outbox initOutbox(String topic, Object message, UUID eventId);
+    void updatePublishedOutbox(UUID eventId);
 
     void retryOutboxEvents();
 }

--- a/concert/src/main/java/com/hhp/concert/Business/service/OutboxServiceImpl.java
+++ b/concert/src/main/java/com/hhp/concert/Business/service/OutboxServiceImpl.java
@@ -1,0 +1,77 @@
+package com.hhp.concert.Business.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hhp.concert.Business.Domain.Outbox;
+import com.hhp.concert.Business.Domain.event.ReservationEvent;
+import com.hhp.concert.Business.Repository.OutboxRepository;
+import com.hhp.concert.Infrastructure.kafka.ReservationMessageProducer;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OutboxServiceImpl implements OutboxService{
+    private static final Logger log = LoggerFactory.getLogger(OutboxServiceImpl.class);
+    private final OutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+    private final ReservationMessageProducer producer;
+
+    @Override
+    @Transactional
+    public Outbox initOutbox(String topic, Object event) {
+        Outbox outbox;
+        try {
+            String message = objectMapper.writeValueAsString(event);
+            return outboxRepository.save(new Outbox(topic, message));
+        }catch (JsonProcessingException e){
+            log.error(e.getMessage());
+            outbox = new Outbox(topic, e.getMessage());
+            outbox.updateFailedStatus();
+            return outboxRepository.save(outbox);
+        }
+
+    }
+
+    @Override
+    @Transactional
+    public void updatePublishedOutbox(Long outboxId) {
+        Outbox outbox = outboxRepository.findById(outboxId).orElse(null);
+        if (outbox != null) {
+            outbox.updatePublishStatus();
+        }
+    }
+
+
+    @Transactional
+    @Override
+    public void retryOutboxEvents() {
+        List<Outbox> outboxList = outboxRepository.findAllByStatus(Outbox.OutboxStatus.INIT);
+        for (Outbox outbox : outboxList) {
+            log.info("outbox createdAt : {}", outbox.getCreatedAt());
+            //이후 실패한 메시지에 대해 Failed에 대한 조회가 필요하다면 상태에 대한 업데이트 필요
+            //상태를 Failed로 바꾸는 것이기에 위 findAllByStatus에서 상태 조회에 대한 부담은 크게 없음
+            if(outbox.getCreatedAt().isBefore(LocalDateTime.now().minusMinutes(5))) {
+                log.info("Outbox event failed, OutboxId : {}, created at: {}, ", outbox.getId(), outbox.getCreatedAt());
+                outbox.updateFailedStatus();
+                continue;
+            }
+            try{
+                ReservationEvent reservationEvent = objectMapper.readValue(outbox.getPayload(), ReservationEvent.class);
+                reservationEvent.setOutboxId(outbox.getId());
+                producer.send(outbox.getTopic(), reservationEvent);
+            }catch (Exception e){
+                log.error("RetryOutboxEvents Exception : {}", e.getMessage());
+            }
+
+        }
+    }
+
+
+}

--- a/concert/src/main/java/com/hhp/concert/Business/service/ReservationService.java
+++ b/concert/src/main/java/com/hhp/concert/Business/service/ReservationService.java
@@ -1,6 +1,7 @@
 package com.hhp.concert.Business.service;
 
 import com.hhp.concert.Business.Domain.Reservation;
+import com.hhp.concert.Business.Domain.event.ReservationEvent;
 
 public interface ReservationService {
     Reservation createReservation(Reservation reservation);
@@ -9,4 +10,6 @@ public interface ReservationService {
     Reservation getReservationByUserId(long userId, long reservationId);
 
     void confirmReservationStatus(long reservationId);
+
+    ReservationEvent createEvent(Long id);
 }

--- a/concert/src/main/java/com/hhp/concert/Business/service/ReservationServiceImpl.java
+++ b/concert/src/main/java/com/hhp/concert/Business/service/ReservationServiceImpl.java
@@ -1,7 +1,10 @@
 package com.hhp.concert.Business.service;
 
+import com.hhp.concert.Business.Domain.Concert;
 import com.hhp.concert.Business.Domain.ConcertSeat;
 import com.hhp.concert.Business.Domain.Reservation;
+import com.hhp.concert.Business.Domain.event.ReservationEvent;
+import com.hhp.concert.Business.Repository.ConcertRepository;
 import com.hhp.concert.Business.Repository.ConcertSeatRepository;
 import com.hhp.concert.Business.Repository.ConcertSessionRepository;
 import com.hhp.concert.Business.Repository.ReservationRepository;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationServiceImpl implements ReservationService{
     private final ReservationRepository reservationRepository;
     private final ConcertSeatRepository concertSeatRepository;
+    private final ConcertRepository concertRepository;
 
     @Override
     public Reservation createReservation(Reservation reservation) {
@@ -42,5 +46,20 @@ public class ReservationServiceImpl implements ReservationService{
         );
         reservation.setStatus(Reservation.ReservationStatus.CONFIRMED);
         reservationRepository.save(reservation);
+    }
+
+    @Override
+    public ReservationEvent createEvent(Long id) {
+        Reservation reservation = reservationRepository.findById(id).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_RESERVATION_ID)
+        );
+        ConcertSeat concertSeat = concertSeatRepository.findById(reservation.getConcertSeatId()).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_SEAT_ID)
+        );
+        Concert concert = concertRepository.findById(reservation.getConcertId()).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_CONCERT_ID)
+        );
+
+        return new ReservationEvent(concert.getId(), concert.getTitle(), concertSeat.getId(), concertSeat.getSeatNumber());
     }
 }

--- a/concert/src/main/java/com/hhp/concert/Infrastructure/DBRepository/outbox/OutboxJpaRepository.java
+++ b/concert/src/main/java/com/hhp/concert/Infrastructure/DBRepository/outbox/OutboxJpaRepository.java
@@ -1,0 +1,12 @@
+package com.hhp.concert.Infrastructure.DBRepository.outbox;
+
+import com.hhp.concert.Business.Domain.Outbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
+
+    List<Outbox> findAllByStatus(Outbox.OutboxStatus status);
+}

--- a/concert/src/main/java/com/hhp/concert/Infrastructure/DBRepository/outbox/OutboxJpaRepository.java
+++ b/concert/src/main/java/com/hhp/concert/Infrastructure/DBRepository/outbox/OutboxJpaRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
-
+    Optional<Outbox> findByEventId(UUID eventId);
     List<Outbox> findAllByStatus(Outbox.OutboxStatus status);
 }

--- a/concert/src/main/java/com/hhp/concert/Infrastructure/DBRepository/outbox/OutboxRepositoryImpl.java
+++ b/concert/src/main/java/com/hhp/concert/Infrastructure/DBRepository/outbox/OutboxRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -20,8 +21,8 @@ public class OutboxRepositoryImpl implements OutboxRepository {
     }
 
     @Override
-    public Optional<Outbox> findById(Long id) {
-        return outboxJpaRepository.findById(id);
+    public Optional<Outbox> findByEventId(UUID eventId) {
+        return outboxJpaRepository.findByEventId(eventId);
     }
 
     @Override

--- a/concert/src/main/java/com/hhp/concert/Infrastructure/DBRepository/outbox/OutboxRepositoryImpl.java
+++ b/concert/src/main/java/com/hhp/concert/Infrastructure/DBRepository/outbox/OutboxRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.hhp.concert.Infrastructure.DBRepository.outbox;
+
+import com.hhp.concert.Business.Domain.Outbox;
+import com.hhp.concert.Business.Repository.OutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public Outbox save(Outbox outbox) {
+        return outboxJpaRepository.save(outbox);
+    }
+
+    @Override
+    public Optional<Outbox> findById(Long id) {
+        return outboxJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Outbox> findAllByStatus(Outbox.OutboxStatus status) {
+        return outboxJpaRepository.findAllByStatus(status);
+    }
+}

--- a/concert/src/main/java/com/hhp/concert/Infrastructure/kafka/ReservationKafkaMessageProducer.java
+++ b/concert/src/main/java/com/hhp/concert/Infrastructure/kafka/ReservationKafkaMessageProducer.java
@@ -1,5 +1,6 @@
 package com.hhp.concert.Infrastructure.kafka;
 
+import com.hhp.concert.Business.Domain.event.ReservationEvent;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +13,7 @@ public class ReservationKafkaMessageProducer {
     private static final Logger log = LoggerFactory.getLogger(ReservationKafkaMessageProducer.class);
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    public void send(String topic, String message) {
+    public void send(String topic,ReservationEvent message) {
         log.info("sending payloa={} to topic={}", message, topic);
         kafkaTemplate.send(topic, message);
     }

--- a/concert/src/main/java/com/hhp/concert/Infrastructure/kafka/ReservationKafkaMessageProducer.java
+++ b/concert/src/main/java/com/hhp/concert/Infrastructure/kafka/ReservationKafkaMessageProducer.java
@@ -1,0 +1,19 @@
+package com.hhp.concert.Infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationKafkaMessageProducer {
+    private static final Logger log = LoggerFactory.getLogger(ReservationKafkaMessageProducer.class);
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void send(String topic, String message) {
+        log.info("sending payloa={} to topic={}", message, topic);
+        kafkaTemplate.send(topic, message);
+    }
+}

--- a/concert/src/main/java/com/hhp/concert/Infrastructure/kafka/ReservationMessageProducer.java
+++ b/concert/src/main/java/com/hhp/concert/Infrastructure/kafka/ReservationMessageProducer.java
@@ -9,12 +9,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ReservationKafkaMessageProducer {
-    private static final Logger log = LoggerFactory.getLogger(ReservationKafkaMessageProducer.class);
+public class ReservationMessageProducer {
+    private static final Logger log = LoggerFactory.getLogger(ReservationMessageProducer.class);
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
+
     public void send(String topic,ReservationEvent message) {
-        log.info("sending payloa={} to topic={}", message, topic);
         kafkaTemplate.send(topic, message);
     }
 }

--- a/concert/src/main/java/com/hhp/concert/Interfaces/KafkaConsumerConfig.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/KafkaConsumerConfig.java
@@ -1,0 +1,47 @@
+package com.hhp.concert.Interfaces;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/concert/src/main/java/com/hhp/concert/Interfaces/KafkaProducerConfig.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/KafkaProducerConfig.java
@@ -1,0 +1,35 @@
+package com.hhp.concert.Interfaces;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/concert/src/main/java/com/hhp/concert/Interfaces/SchedulerConfig.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/SchedulerConfig.java
@@ -1,5 +1,6 @@
 package com.hhp.concert.Interfaces;
 
+import com.hhp.concert.Business.service.OutboxService;
 import com.hhp.concert.Business.service.WaitingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -11,9 +12,15 @@ import org.springframework.scheduling.annotation.Scheduled;
 @RequiredArgsConstructor
 public class SchedulerConfig {
     private final WaitingService waitingService;
+    private final OutboxService outboxService;
 
     @Scheduled(fixedRate = 10000) // 10초마다 실행
     public void scheduleTokenService() {
         waitingService.updateQueue();
+    }
+
+    @Scheduled(fixedRate = 10000) // 10초마다 실행
+    public void scheduleRetrySendMessage() {
+        outboxService.retryOutboxEvents();
     }
 }

--- a/concert/src/main/java/com/hhp/concert/Interfaces/consumer/DataPlatFormEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/consumer/DataPlatFormEventListener.java
@@ -1,0 +1,19 @@
+package com.hhp.concert.Interfaces.consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataPlatFormEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(DataPlatFormEventListener.class);
+
+    @KafkaListener(topics = "concert-reserve-data", groupId = "${spring.kafka.consumer.group-id}")
+    public void consume(Object message) {
+        log.info("consume");
+        log.info("Consumed message: {}", message);
+    }
+
+}

--- a/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
@@ -21,9 +21,9 @@ public class OutboxEventListener {
     private final OutboxService outboxService;
 
     @KafkaListener(topics = "concert-reserve-data")
-    public void consume(ReservationEvent event) {
-        log.info("consumed event: {}", event.toString());
-        outboxService.updatePublishedOutbox(event.getOutboxId());
+    public void reservationOutboxConsume(ReservationEvent event) {
+
+        outboxService.updatePublishedOutbox(event.getEventId());
     }
 
 

--- a/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
@@ -1,7 +1,10 @@
 package com.hhp.concert.Interfaces.consumer;
 
 import com.hhp.concert.Business.Domain.event.ReservationEvent;
+import com.hhp.concert.Business.Repository.OutboxRepository;
+import com.hhp.concert.Business.service.OutboxService;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -11,23 +14,16 @@ import java.util.concurrent.CountDownLatch;
 
 @Component
 @Getter
+@RequiredArgsConstructor
 public class OutboxEventListener {
-    private CountDownLatch latch = new CountDownLatch(10);
+    private CountDownLatch latch = new CountDownLatch(1);
     private static final Logger log = LoggerFactory.getLogger(OutboxEventListener.class);
+    private final OutboxService outboxService;
 
     @KafkaListener(topics = "concert-reserve-data")
-    public void consume(ReservationEvent message) {
-        message.outboxId();
-        log.info("Consumed message: {}", message);
-    }
-
-    @KafkaListener(topics = "concert-reserve-data", groupId = "test")
-    public void consumeTest(ReservationEvent message){
-        log.info("test");
-    }
-
-    public void resetLatch() {
-        CountDownLatch latch = new CountDownLatch(1);
+    public void consume(ReservationEvent event) {
+        log.info("consumed event: {}", event.toString());
+        outboxService.updatePublishedOutbox(event.getOutboxId());
     }
 
 

--- a/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
@@ -1,19 +1,22 @@
 package com.hhp.concert.Interfaces.consumer;
 
+import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+
 @Component
-public class DataPlatFormEventListener {
+@Getter
+public class OutboxEventListener {
+    private static final Logger log = LoggerFactory.getLogger(OutboxEventListener.class);
 
-    private static final Logger log = LoggerFactory.getLogger(DataPlatFormEventListener.class);
-
-    @KafkaListener(topics = "concert-reserve-data", groupId = "${spring.kafka.consumer.group-id}")
-    public void consume(Object message) {
+    @KafkaListener(topics = "concert-reserve-data")
+    public void consume(String message) {
         log.info("consume");
         log.info("Consumed message: {}", message);
     }
+
 
 }

--- a/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
@@ -6,17 +6,22 @@ import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.CountDownLatch;
 
 @Component
 @Getter
 public class OutboxEventListener {
+    private CountDownLatch latch = new CountDownLatch(10);
     private static final Logger log = LoggerFactory.getLogger(OutboxEventListener.class);
 
     @KafkaListener(topics = "concert-reserve-data")
-    public void consume(String message) {
+    public void consume(Object message) {
         log.info("consume");
         log.info("Consumed message: {}", message);
     }
 
+    public void resetLatch() {
+        CountDownLatch latch = new CountDownLatch(1);
+    }
 
 }

--- a/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/consumer/OutboxEventListener.java
@@ -1,5 +1,6 @@
 package com.hhp.concert.Interfaces.consumer;
 
+import com.hhp.concert.Business.Domain.event.ReservationEvent;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,13 +16,19 @@ public class OutboxEventListener {
     private static final Logger log = LoggerFactory.getLogger(OutboxEventListener.class);
 
     @KafkaListener(topics = "concert-reserve-data")
-    public void consume(Object message) {
-        log.info("consume");
+    public void consume(ReservationEvent message) {
+        message.outboxId();
         log.info("Consumed message: {}", message);
+    }
+
+    @KafkaListener(topics = "concert-reserve-data", groupId = "test")
+    public void consumeTest(ReservationEvent message){
+        log.info("test");
     }
 
     public void resetLatch() {
         CountDownLatch latch = new CountDownLatch(1);
     }
+
 
 }

--- a/concert/src/main/java/com/hhp/concert/Interfaces/event/CustomEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/event/CustomEventListener.java
@@ -2,9 +2,12 @@ package com.hhp.concert.Interfaces.event;
 
 import com.hhp.concert.Business.Domain.DataPlatformSendEvent;
 import com.hhp.concert.util.exception.CustomException;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,22 +15,18 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import java.util.Map;
 
 @Component
+@RequiredArgsConstructor
 public class CustomEventListener {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     private static final Logger log = LoggerFactory.getLogger(CustomEventListener.class);
 
     @Async
     @TransactionalEventListener
-    public void handleCustomEvent(DataPlatformSendEvent event) throws InterruptedException {
-        log.info("handleCustomEvent");
-        Thread.sleep(10000);
-        try {
-            //플랫폼 로직
+    public void handleCustomEvent(DataPlatformSendEvent event) {
 
-            log.info(event.toString());
-            throw new Exception("플랫폼 에러");
-        }catch (Exception e){
-            log.error("플랫폼 전송 오류");
-        }
+        log.info("kafka send");
+        kafkaTemplate.send("concert-reserve-data", "event");
     }
 }

--- a/concert/src/main/java/com/hhp/concert/Interfaces/event/CustomEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/event/CustomEventListener.java
@@ -1,33 +1,36 @@
 package com.hhp.concert.Interfaces.event;
 
-import com.hhp.concert.Business.Domain.event.DataPlatformSendEvent;
+import com.hhp.concert.Business.Domain.event.ReservationEvent;
+import com.hhp.concert.Business.Repository.OutboxRepository;
+import com.hhp.concert.Business.service.OutboxService;
 import com.hhp.concert.Infrastructure.kafka.ReservationKafkaMessageProducer;
-import com.hhp.concert.util.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.event.EventListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class CustomEventListener {
 
     private final ReservationKafkaMessageProducer producer;
+    private final OutboxService outboxService;
 
     private static final Logger log = LoggerFactory.getLogger(CustomEventListener.class);
 
     @Async
-    @TransactionalEventListener
-    public void handleCustomEvent(DataPlatformSendEvent event) {
-
-        log.info("kafka send");
-        producer.send("concert-reserve-data", "event");
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void reservationDataSand(ReservationEvent event) {
+        producer.send("concert-reserve-data", event);
     }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void initOutbox(ReservationEvent event) {
+        outboxService.initOutbox("concert-reserve-data", event);
+    }
+
 }

--- a/concert/src/main/java/com/hhp/concert/Interfaces/event/CustomEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/event/CustomEventListener.java
@@ -24,17 +24,12 @@ public class CustomEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void reservationDataSand(ReservationEvent event) {
-        Outbox outbox = outboxService.initOutbox("concert-reserve-data", event);
-        event.setOutboxId(outbox.getId());
         producer.send("concert-reserve-data", event);
     }
 
-
-    //비동기 이벤트 분리 시 outbox에 대한 Id를 위에 send에 넣을 수 없음
-//    @Async
-//    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-//    public void initOutbox(ReservationEvent event) {
-//        Outbox outbox = outboxService.initOutbox("concert-reserve-data", event);
-//    }
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void reservationInitOutbox(ReservationEvent event) {
+        outboxService.initOutbox("concert-reserve-data", event, event.getEventId());
+    }
 
 }

--- a/concert/src/main/java/com/hhp/concert/Interfaces/event/CustomEventListener.java
+++ b/concert/src/main/java/com/hhp/concert/Interfaces/event/CustomEventListener.java
@@ -1,6 +1,7 @@
 package com.hhp.concert.Interfaces.event;
 
-import com.hhp.concert.Business.Domain.DataPlatformSendEvent;
+import com.hhp.concert.Business.Domain.event.DataPlatformSendEvent;
+import com.hhp.concert.Infrastructure.kafka.ReservationKafkaMessageProducer;
 import com.hhp.concert.util.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -18,7 +19,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CustomEventListener {
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ReservationKafkaMessageProducer producer;
 
     private static final Logger log = LoggerFactory.getLogger(CustomEventListener.class);
 
@@ -27,6 +28,6 @@ public class CustomEventListener {
     public void handleCustomEvent(DataPlatformSendEvent event) {
 
         log.info("kafka send");
-        kafkaTemplate.send("concert-reserve-data", "event");
+        producer.send("concert-reserve-data", "event");
     }
 }

--- a/concert/src/main/java/com/hhp/concert/application/ConcertFacade.java
+++ b/concert/src/main/java/com/hhp/concert/application/ConcertFacade.java
@@ -1,7 +1,7 @@
 package com.hhp.concert.application;
 
 import com.hhp.concert.Business.Domain.*;
-import com.hhp.concert.Business.Domain.event.DataPlatformSendEvent;
+import com.hhp.concert.Business.Domain.event.ReservationEvent;
 import com.hhp.concert.Business.service.*;
 import com.hhp.concert.Business.dto.GetSessionDateResponseDto;
 import com.hhp.concert.Business.dto.GetSessionSeatResponseDto;
@@ -57,11 +57,10 @@ public class ConcertFacade {
                 user.getId(), concertId, sessionId, seatId, concertSeat.getPrice());
 
         //예약 저장
-        Reservation reservation = reservationService.createReservation(new Reservation(user.getId(), sessionId, concertSeat.getId(), concertSeat.getPrice()));
+        Reservation reservation = reservationService.createReservation(new Reservation(user.getId(), concertId, sessionId, concertSeat.getId(), concertSeat.getPrice()));
 
-        applicationEventPublisher.publishEvent(new DataPlatformSendEvent<Map<String, Long>>(
-                Map.of("ConcertId", concertId, "ConcertSeatId", concertSeat.getId(), "ConcertSeatNumber", (long) concertSeat.getSeatNumber())
-        ));
+        ReservationEvent reservationEvent = reservationService.createEvent(reservation.getId());
+        applicationEventPublisher.publishEvent(reservationEvent);
 
 
         return new ReservationResponseDto(reservation.getId(), reservation.getReservationPrice());

--- a/concert/src/main/java/com/hhp/concert/application/ConcertFacade.java
+++ b/concert/src/main/java/com/hhp/concert/application/ConcertFacade.java
@@ -1,6 +1,7 @@
 package com.hhp.concert.application;
 
 import com.hhp.concert.Business.Domain.*;
+import com.hhp.concert.Business.Domain.event.DataPlatformSendEvent;
 import com.hhp.concert.Business.service.*;
 import com.hhp.concert.Business.dto.GetSessionDateResponseDto;
 import com.hhp.concert.Business.dto.GetSessionSeatResponseDto;

--- a/concert/src/main/java/com/hhp/concert/util/TestDatabaseManager.java
+++ b/concert/src/main/java/com/hhp/concert/util/TestDatabaseManager.java
@@ -95,7 +95,7 @@ public class TestDatabaseManager implements InitializingBean {
                 sessionList.add(session);
                 for (int k = 0; k < 50; k++) {
                     ConcertSeat seat = new ConcertSeat(k, 10000, true, 1L);
-                    Reservation reservation = new Reservation(1L, 1L, 1L, 3000);
+                    Reservation reservation = new Reservation(1L, 1L, 1L, 1L, 3000);
                     seatList.add(seat);
                     reservationList.add(reservation);
                     if (seatList.size() % batchSize == 0) {

--- a/concert/src/main/resources/application.properties
+++ b/concert/src/main/resources/application.properties
@@ -32,3 +32,6 @@ spring.jpa.properties.hibernate.jdbc.batch_size=50
 spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
 spring.jpa.properties.hibernate.generate_statistics=false
+
+spring.kafka.bootstrap-servers=${KAFKA_BROKER_ADDRESS:localhost:9092}
+spring.kafka.consumer.group-id=reserve-data

--- a/concert/src/test/java/com/hhp/concert/cache/QueryTest.java
+++ b/concert/src/test/java/com/hhp/concert/cache/QueryTest.java
@@ -68,7 +68,7 @@ public class QueryTest {
     public void testReservationQueryExecutionTime(){
         long startTime, endTime, duration;
         long userId = 213L;
-        Reservation reservation = reservationJpaRepository.save(new Reservation(userId, 2L, 2L, 3000));
+        Reservation reservation = reservationJpaRepository.save(new Reservation(userId, 3L, 2L, 2L, 3000));
         startTime = System.currentTimeMillis();
 
         Reservation result = reservationJpaRepository.findById(reservation.getId()).get();

--- a/concert/src/test/java/com/hhp/concert/concurrencyTest/ConcurrencyTest.java
+++ b/concert/src/test/java/com/hhp/concert/concurrencyTest/ConcurrencyTest.java
@@ -178,7 +178,7 @@ public class ConcurrencyTest {
         Long seatId = 1241241L;
         ConcertSeat concertSeat = concertSeatJpaRepository.save(new ConcertSeat(seatId, seatNumber, seatPrice, true, concertSession.getId()));
 
-        Reservation reservation = reservationJpaRepository.save(new Reservation(user.getId(), concertSession.getId(), concertSeat.getId(), concertSeat.getPrice()));
+        Reservation reservation = reservationJpaRepository.save(new Reservation(user.getId(), concert.getId(), concertSession.getId(), concertSeat.getId(), concertSeat.getPrice()));
 
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);

--- a/concert/src/test/java/com/hhp/concert/event/KafkaEventTest.java
+++ b/concert/src/test/java/com/hhp/concert/event/KafkaEventTest.java
@@ -1,0 +1,51 @@
+package com.hhp.concert.event;
+
+
+
+import com.hhp.concert.Infrastructure.kafka.ReservationKafkaMessageProducer;
+import com.hhp.concert.Interfaces.consumer.OutboxEventListener;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1, controlledShutdown = false, brokerProperties = {"listeners=PLAINTEXT://localhost:9092", "port=9092"})
+class KafkaEventTest {
+
+    @Autowired
+    private OutboxEventListener consumer;
+
+    @Autowired
+    private ReservationKafkaMessageProducer producer;
+
+    @Test
+    public void kafkaEventPingPongTest()
+            throws Exception {
+
+        String topic = "concert-reserve-data";
+
+
+        int testCnt = 0;
+        for (int i = 0; i < 9; i++) {
+            producer.send(topic, "test");
+
+            testCnt++;
+        };
+
+        // 모든 메시지를 수신할 때까지 기다립니다 , consumer latch 로 관리할 수 있습니다.
+        consumer.getLatch().await(10, TimeUnit.SECONDS);
+
+    }
+
+}

--- a/concert/src/test/java/com/hhp/concert/integrationTest/PaymentTest.java
+++ b/concert/src/test/java/com/hhp/concert/integrationTest/PaymentTest.java
@@ -114,7 +114,7 @@ public class PaymentTest {
         ConcertSeat concertSeat = new ConcertSeat(seatNumber, 1000, true, session.getId());
         concertSeatList.add(concertSeat);
         concertSeatJpaRepository.saveAll(concertSeatList);
-        Reservation reservation = reservationJpaRepository.save(new Reservation(user.getId(), session.getId(), concertSeat.getId(), concertSeat.getPrice()));
+        Reservation reservation = reservationJpaRepository.save(new Reservation(user.getId(), concert.getId(), session.getId(), concertSeat.getId(), concertSeat.getPrice()));
 
         PaymentRequestDto requestDto = new PaymentRequestDto(user.getId(), reservation.getId());
 

--- a/concert/src/test/java/com/hhp/concert/unitTest/ConcertFacadeTest.java
+++ b/concert/src/test/java/com/hhp/concert/unitTest/ConcertFacadeTest.java
@@ -119,7 +119,7 @@ public class ConcertFacadeTest {
         ConcertSession concertSession = new ConcertSession(sessionId, LocalDateTime.now(), concertId);
         ConcertSeat concertSeat = new ConcertSeat(seatId, 1, 1000, false, concertSession.getId());
         Reservation reservation = new Reservation(reservationId, concertId, user.getId(), concertSession.getId(), concertSeat.getId(), concertSeat.getPrice(), Reservation.ReservationStatus.PENDING);
-        ReservationEvent reservationEvent = new ReservationEvent(concertId, "", seatId, 1, 1L);
+        ReservationEvent reservationEvent = new ReservationEvent(concertId, "", seatId, 1);
         given(concertService.getConcert(concertId)).willReturn(concert);
         given(concertSessionService.getSessionByOpenAndConcertId(concertId, sessionId)).willReturn(concertSession);
         given(concertSeatService.getSeatsForConcertSessionAndAvailable(sessionId, seatId)).willReturn(concertSeat);

--- a/concert/src/test/java/com/hhp/concert/unitTest/ConcertFacadeTest.java
+++ b/concert/src/test/java/com/hhp/concert/unitTest/ConcertFacadeTest.java
@@ -119,7 +119,7 @@ public class ConcertFacadeTest {
         ConcertSession concertSession = new ConcertSession(sessionId, LocalDateTime.now(), concertId);
         ConcertSeat concertSeat = new ConcertSeat(seatId, 1, 1000, false, concertSession.getId());
         Reservation reservation = new Reservation(reservationId, concertId, user.getId(), concertSession.getId(), concertSeat.getId(), concertSeat.getPrice(), Reservation.ReservationStatus.PENDING);
-        ReservationEvent reservationEvent = new ReservationEvent(concertId, "", seatId, 1);
+        ReservationEvent reservationEvent = new ReservationEvent(concertId, "", seatId, 1, 1L);
         given(concertService.getConcert(concertId)).willReturn(concert);
         given(concertSessionService.getSessionByOpenAndConcertId(concertId, sessionId)).willReturn(concertSession);
         given(concertSeatService.getSeatsForConcertSessionAndAvailable(sessionId, seatId)).willReturn(concertSeat);

--- a/concert/src/test/java/com/hhp/concert/unitTest/ConcertFacadeTest.java
+++ b/concert/src/test/java/com/hhp/concert/unitTest/ConcertFacadeTest.java
@@ -1,6 +1,7 @@
 package com.hhp.concert.unitTest;
 
 import com.hhp.concert.Business.Domain.*;
+import com.hhp.concert.Business.Domain.event.ReservationEvent;
 import com.hhp.concert.Business.service.*;
 import com.hhp.concert.Business.dto.GetSessionDateResponseDto;
 import com.hhp.concert.Business.dto.GetSessionSeatResponseDto;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
 
 
 import java.time.LocalDateTime;
@@ -47,6 +49,9 @@ public class ConcertFacadeTest {
 
     @Mock
     private JwtService jwtService;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
 
 
@@ -113,14 +118,16 @@ public class ConcertFacadeTest {
         Concert concert = new Concert(concertId, "test");
         ConcertSession concertSession = new ConcertSession(sessionId, LocalDateTime.now(), concertId);
         ConcertSeat concertSeat = new ConcertSeat(seatId, 1, 1000, false, concertSession.getId());
-        Reservation reservation = new Reservation(reservationId, user.getId(), concertSession.getId(), concertSeat.getId(), concertSeat.getPrice(), Reservation.ReservationStatus.PENDING);
-
+        Reservation reservation = new Reservation(reservationId, concertId, user.getId(), concertSession.getId(), concertSeat.getId(), concertSeat.getPrice(), Reservation.ReservationStatus.PENDING);
+        ReservationEvent reservationEvent = new ReservationEvent(concertId, "", seatId, 1);
         given(concertService.getConcert(concertId)).willReturn(concert);
         given(concertSessionService.getSessionByOpenAndConcertId(concertId, sessionId)).willReturn(concertSession);
         given(concertSeatService.getSeatsForConcertSessionAndAvailable(sessionId, seatId)).willReturn(concertSeat);
         given(userService.getUser(userId)).willReturn(user);
         given(reservationService.createReservation(any(Reservation.class))).willReturn(reservation);
         given(concertService.getAvailableReservationSeats(concertId, sessionId, seatId)).willReturn(concertSeat);
+        given(reservationService.createEvent(reservationId)).willReturn(reservationEvent);
+//        given(applicationEventPublisher.publishEvent(reservationEvent));
         ReservationResponseDto response = concertFacade.reserveConcert(concertId, sessionId, seatId, userId);
 
         assertEquals(response.getReservationId(), reservation.getId());

--- a/concert/src/test/java/com/hhp/concert/unitTest/JwtFilterTest.java
+++ b/concert/src/test/java/com/hhp/concert/unitTest/JwtFilterTest.java
@@ -79,7 +79,7 @@ public class JwtFilterTest {
         Concert concert = new Concert(concertId, "test");
         ConcertSession concertSession = new ConcertSession(sessionId, LocalDateTime.now(), concertId);
         ConcertSeat concertSeat = new ConcertSeat(seatNumber, 1, 1000, false, concertSession.getId());
-        Reservation reservation = new Reservation(reservationId, user.getId(), concertSession.getId(), concertSeat.getId(), concertSeat.getPrice(), Reservation.ReservationStatus.PENDING);
+        Reservation reservation = new Reservation(reservationId, user.getId(), concertId, concertSession.getId(), concertSeat.getId(), concertSeat.getPrice(), Reservation.ReservationStatus.PENDING);
 
         when(concertService.getConcert(concertId)).thenReturn(concert);
         when(concertSessionService.getSessionByOpenAndConcertId(concertId, sessionId)).thenReturn(concertSession);

--- a/concert/src/test/java/com/hhp/concert/unitTest/PaymentFacadeTest.java
+++ b/concert/src/test/java/com/hhp/concert/unitTest/PaymentFacadeTest.java
@@ -103,7 +103,7 @@ public class PaymentFacadeTest {
 
         ConcertSeat concertSeat = new ConcertSeat(seatId, 1, price, false, concertSession.getId());
 
-        Reservation reservation = new Reservation(user.getId(), concertSession.getId(), concertSeat.getId(), price);
+        Reservation reservation = new Reservation(user.getId(), concert.getId(), concertSession.getId(), concertSeat.getId(), price);
 
         PaymentHistory paymentHistory = new PaymentHistory(price, user, reservation);
 
@@ -162,7 +162,7 @@ public class PaymentFacadeTest {
 
         ConcertSeat concertSeat = new ConcertSeat(1, price, false, 1L);
 
-        Reservation reservation = new Reservation(reservationId, user.getId(), concertSession.getId(), concertSeat.getId(), price, Reservation.ReservationStatus.PENDING);
+        Reservation reservation = new Reservation(reservationId, concert.getId(), user.getId(), concertSession.getId(), concertSeat.getId(), price, Reservation.ReservationStatus.PENDING);
         PaymentHistory paymentHistory = new PaymentHistory(concertSeat.getPrice(), user, reservation);
 
         given(userService.getUser(userId)).willReturn(user);

--- a/concert/src/test/resources/application-test.properties
+++ b/concert/src/test/resources/application-test.properties
@@ -3,3 +3,7 @@ control.size = 20
 
 spring.data.redis.host=localhost
 spring.data.redis.port=6378
+
+
+spring.kafka.bootstrap-servers=${KAFKA_BROKER_ADDRESS:localhost:9092}
+spring.kafka.consumer.group-id=reserve-data


### PR DESCRIPTION
## Kafka
1. Consumer, Producer 구현
    - Config 구현 및 docker Compose 추가
        - Docker Container로 환경 구현 시 Zookeeper가 선 시작이 필수로 요구되는데 해당부분 Docker HealthCheck로 해결
        - Test의 경우 단순 로그이기에 이후 테스트에서 로직을 활용한 테스트 진행
    - 구현 Commit : ef23748148e9914d7d831b769b05b065f4f66291
    - Docker Compose Commit : 8da74aa02de09ec189d0bfdd91f26d90ed4b6753

2. Outbox 로직 구현
    - 기존 EventListener 에 InitOutbox 로직 추가
    - Outbox에 Status를 이용해 메시지 발행 핸들링
    - 스케줄러 추가하여 미발행 메시지 재발행 로직 추가
        - 미발행 5분이 지난 로직에 대한 Failed 처리 및 Log 추가
    - Test Code 추가
    - 구현 Commit : 546d5767cb87fdf599c61a1ab3e6792591a7c39d
    - 스케줄러 Commit : c80a7d0fd02d5b22eb88d3509faee325818a13ac
    - Test Code Commit : faf92e09163069ad5dfc7900689b761a723e8fff
    - 기존 Outbox 생성 Listener와 Kafka 전송 Listener간의 연관 구조가 전혀 없어 로직을 하나로 처리
        - 이후 Event에서 UUID를 자동 생성하여 Outbox에서 해당 Event의 UUID를 저장하여 UUID 조회로 로직 변경
        - Outbox 생성 Listener와 Kafka 전송 Listener 분리
        - 구현 Commit : 9c22ab42cf0d07f115a4f1e996fb0ea06b887fe5